### PR TITLE
added support for billing phone and custom order number

### DIFF
--- a/woocommerce-delivery-notes-print.php
+++ b/woocommerce-delivery-notes-print.php
@@ -93,18 +93,6 @@ if ( !function_exists( 'wcdn_template_print_button' ) ) {
 }
 	
 /**
- * Return default logo 
- *
- * @since 1.0
- */
-if ( !function_exists( 'wcdn_company_logo' ) ) {
-	function wcdn_company_logo() {
-		global $wcdn;
-		return $wcdn->print->get_setting( 'company_logo' );
-	}
-}
-
-/**
  * Return default title name of Delivery Note 
  *
  * @since 1.0
@@ -114,7 +102,7 @@ if ( !function_exists( 'wcdn_company_name' ) ) {
 		global $wcdn;
 		$name = trim( $wcdn->print->get_setting( 'custom_company_name' ) );
 		if( !empty( $name ) ) {
-			return wpautop( wptexturize( $name ) , 0);
+			return wpautop( $name );
 		} else {
 			return get_bloginfo( 'name' );
 		}
@@ -274,6 +262,21 @@ if ( ! function_exists( 'wcdn_shipping_notes' ) ) {
 }
 
 /**
+ * Return billing phone
+ *
+ * @since 1.0
+ *
+ * @global $wcdn->print
+ * @return string billing phone
+ */
+if ( ! function_exists( 'wcdn_billing_phone' ) ) {
+	function wcdn_billing_phone() {
+		global $wcdn;
+		return $wcdn->print->get_order()->billing_phone;
+	}
+}
+
+/**
  * Return order id
  *
  * @since 1.0
@@ -287,7 +290,16 @@ if ( ! function_exists( 'wcdn_order_number' ) ) {
 		$before = trim( $wcdn->print->get_setting( 'before_order_number' ) );
 		$after = trim( $wcdn->print->get_setting( 'after_order_number' ) );
 		$offset = trim( $wcdn->print->get_setting( 'order_number_offset' ) );
-		$number = $before . ( intval( $offset ) + intval( $wcdn->print->order_id ) ) . $after;
+
+		// try to get custom order number as provided by the plugin
+		// http://wordpress.org/extend/plugins/woocommerce-sequential-order-numbers/
+		$order_id     = $wcdn->print->order_id;
+		$order_number = $wcdn->print->get_order()->order_custom_fields['_order_number'][0];
+		
+		// if custom order number is zero, fall back to ID
+		if ( intval($order_number) != 0 ) $order_id = $order_number;
+
+		$number = $before . ( intval( $offset ) + intval( $order_id ) ) . $after;
 		return $number;
 	}
 }


### PR DESCRIPTION
Hi,

I added a function for billing phone number - and I included support for a custom order number like provided by this plugin: http://wordpress.org/extend/plugins/woocommerce-sequential-order-numbers/

If there is no custom order number, the default (id) will be used. This is very convenient for users of the above plugin, since they don't have to edit the template. (and I think, many german users will need the custom order number plugin...)

thanks in advance,

Matt
