### PR TITLE
added prices with tax, taxrate and full item array to pass to template

### DIFF
--- a/classes/class-wcdn-print.php
+++ b/classes/class-wcdn-print.php
@@ -191,6 +191,18 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes_Print' ) ) {
 					
 					// Set item dimensions
 					$data['dimensions'] = $product->get_dimensions();
+
+					// Get item tax rate
+					$data['taxrate'] = $item['taxrate'];
+
+					// Get line total price including tax
+					$data['price_with_tax'] = woocommerce_price( ( $item['line_total'] + $item['line_tax'] ), array( 'ex_tax_label' => 0 ) );
+
+					// Get single item price including tax
+					$data['single_price_with_tax'] = woocommerce_price( ( $item['line_total'] + $item['line_tax'] ) / $item['qty'], array( 'ex_tax_label' => 0 ) );
+
+					// Pass complete item array - more freedom for template developers
+					$data['item'] = $item;
 					
 					$data_list[] = $data;
 				}


### PR DESCRIPTION
Hi again,

I added some more fields to the $items array sent to the template. Mostly prices with taxes and taxrate, which you might or might not regard as useful, but please include at least the last line of these:

```
                // Get item tax rate
                $data['taxrate'] = $item['taxrate'];

                // Get line total price including tax
                $data['price_with_tax'] = woocommerce_price( ( $item['line_total'] + $item['line_tax'] ), array( 'ex_tax_label' => 0 ) );

                // Get single item price including tax
                $data['single_price_with_tax'] = woocommerce_price( ( $item['line_total'] + $item['line_tax'] ) / $item['qty'], array( 'ex_tax_label' => 0 ) );

                // Pass complete item array - more freedom for template developers
                $data['item'] = $item;
```

If you include the whole $item object (array) in the $data that gets passed to the template, it will be much easier for a template developer, to implement things like prices with taxes by themselves - directly in the template.

Thanks in advance,

Matt
