### PR TITLE
Add woocommerce_invoice_print shortcode to allow users to print their own invoices from the front end

### DIFF
--- a/classes/class-wcdn-print.php
+++ b/classes/class-wcdn-print.php
@@ -39,7 +39,7 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes_Print' ) ) {
 		/**
 		 * Load the admin hooks
 		 */
-		public function load_hooks() {	
+		public function load_hooks() {
 			add_action('wp_ajax_generate_print_content', array($this, 'generate_print_content_ajax'));
 		}
 
@@ -58,24 +58,24 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes_Print' ) ) {
 		 * Load and generate the template output with ajax
 		 */
 		public function generate_print_content_ajax() {		
-			// Let the backend only access the page
-			if( !is_admin() ) {
-				wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-delivery-notes' ) );
-			}
-			
-			// Check the user privileges
-			if( !current_user_can( 'manage_woocommerce_orders' ) && !current_user_can( 'edit_shop_orders' ) ) {
-				wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-delivery-notes' ) );
-			}
 			
 			// Check the nonce
-			if( empty( $_GET['action'] ) || !check_admin_referer( $_GET['action'] ) ) {
+			if( empty( $_GET['action'] ) || ! is_user_logged_in() || !check_admin_referer( $_GET['action'] ) ) {
 				wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-delivery-notes' ) );
 			}
 			
 			// Check if all parameters are set
 			if( empty( $_GET['template_type'] ) || empty( $_GET['order_id'] ) ) {
 				wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-delivery-notes' ) );
+			}
+			
+			// Check the user privileges
+			if( !current_user_can( 'manage_woocommerce_orders' ) && !current_user_can( 'edit_shop_orders' ) ) {
+				$user_id = get_current_user_id();
+				$order = new WC_Order( (int)$_GET['order_id'] );
+				if ($order->user_id != $user_id) {
+					wp_die( __( 'You do not have sufficient permissions to access this page.', 'woocommerce-delivery-notes' ) );
+				}
 			}
 			
 			// Generate the output

--- a/classes/class-wcdn-writepanel.php
+++ b/classes/class-wcdn-writepanel.php
@@ -75,7 +75,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Writepanel' ) ) {
 			?>
 			<a href="<?php echo wp_nonce_url( admin_url( 'admin-ajax.php?action=generate_print_content&template_type=invoice&order_id=' . $order->id ), 'generate_print_content' ); ?>" class="button tips print-preview-button" target="_blank" alt="<?php esc_attr_e( 'Print Invoice', 'woocommerce-delivery-notes' ); ?>" data-tip="<?php esc_attr_e( 'Print Invoice', 'woocommerce-delivery-notes' ); ?>">
 				<span><?php _e( 'Print Invoice', 'woocommerce-delivery-notes' ); ?></span>
-				<img src="<?php echo WooCommerce_Delivery_Notes::$plugin_url . 'images/print-invoice.png'; ?>" alt="<?php esc_attr_e( 'Print Delivery Note', 'woocommerce-delivery-notes' ); ?>" width="14">
+				<img src="<?php echo WooCommerce_Delivery_Notes::$plugin_url . 'images/print-invoice.png'; ?>" alt="<?php esc_attr_e( 'Print Invoice', 'woocommerce-delivery-notes' ); ?>" width="14">
 			</a>
 			<a href="<?php echo wp_nonce_url( admin_url( 'admin-ajax.php?action=generate_print_content&template_type=delivery-note&order_id=' . $order->id ), 'generate_print_content' ); ?>" class="button tips print-preview-button" target="_blank" alt="<?php esc_attr_e( 'Print Delivery Note', 'woocommerce-delivery-notes' ); ?>" data-tip="<?php esc_attr_e( 'Print Delivery Note', 'woocommerce-delivery-notes' ); ?>">
 				<span><?php _e( 'Print Delivery Note', 'woocommerce-delivery-notes' ); ?></span>

--- a/readme.txt
+++ b/readme.txt
@@ -96,6 +96,9 @@ For custom and update-secure language files please upload them to `/wp-content/l
 
 == Changelog ==
 
+= 2.0.3 =
+* NEW: Shortcode (woocommerce_delivery_notes_print) to provide invoice links on the frontend
+
 = 2.0.2 =
 * FIX: The print data is now generated with the order metadata. This solves a problem where the items weren't displayed when the product was deleted. (thanks MDesigner0)
 * UPDATE: Added some missing translations to the pot.

--- a/woocommerce-delivery-notes.php
+++ b/woocommerce-delivery-notes.php
@@ -6,15 +6,15 @@
  * Plugin Name: WooCommerce Print Invoices & Delivery Notes
  * Plugin URI: https://github.com/piffpaffpuff/woocommerce-delivery-notes
  * Description: Print order invoices & delivery notes for WooCommerce shop plugin. You can add company/shop info as well as personal notes & policies to print pages.
- * Version: 2.0.2
- * Author: Steve Clark, Triggvy Gunderson, David Decker
+ * Version: 2.0.3
+ * Author: Steve Clark, Triggvy Gunderson, David Decker, David Anderson
  * Author URI: https://github.com/piffpaffpuff/woocommerce-delivery-notes
  * License: GPLv3 or later
  * License URI: http://www.opensource.org/licenses/gpl-license.php
  * Text Domain: woocommerce-delivery-notes
  * Domain Path: /languages/
  *
- * Copyright 2011-2012 Steve Clark, Trigvvy Gunderson, David Decker - DECKERWEB
+ * Copyright 2011-2013 Steve Clark, Trigvvy Gunderson, David Decker - DECKERWEB, David Anderson - http://updraftplus.com
  *		
  *     This file is part of WooCommerce Print Invoices & Delivery Notes,
  *     a plugin for WordPress.
@@ -99,6 +99,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 				$this->settings->load();
 				$this->print = new WooCommerce_Delivery_Notes_Print();
 				$this->print->load();
+				add_shortcode('woocommerce_invoice_print', array($this, 'shortcode_woocommerce_invoice_print'));
 			}
 		}
 		
@@ -148,6 +149,38 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 			} else {
 				return false;
 			}
+		}
+
+		/**
+		* Front-end shortcode
+		*/
+		public function shortcode_woocommerce_invoice_print($atts) {
+
+			$order_id = ( isset( $_GET['order'] ) ) ? $_GET['order'] : 0;
+			if (empty($order_id)) return '';
+
+			$order = new WC_Order( $order_id );
+
+			if ( ! is_user_logged_in() ) return '';
+
+			$user_id = get_current_user_id();
+
+			if ( $order->user_id != $user_id ) {
+				return '';
+			}
+
+			$nonce_url = wp_nonce_url( admin_url( 'admin-ajax.php?action=generate_print_content&template_type=invoice&order_id=' . $order->id ), 'generate_print_content' );
+			$print_invoice = esc_attr_e( 'Print Invoice', 'woocommerce-delivery-notes' );
+			$plugin_url = WooCommerce_Delivery_Notes::$plugin_url;
+
+			$ret = <<<ENDHERE
+			<a href="$nonce_url" class="button tips print-preview-button" target="_blank" alt="$print_invoice" data-tip="$print_invoice">
+				<span>$print_invoice</span>
+				<img src="${plugin_url}images/print-invoice.png" alt="$print_invoice" width="14">
+			</a>
+ENDHERE;
+
+			return $ret;
 		}
 	}
 }


### PR DESCRIPTION
Hi,

This is my first time forking something on Github, so be nice to me!

I like and use this plugin... but I had the need for my users to be able to print their own invoices from their own orders. This branch adds a shortcode, [woocommerce_invoice_print], which should be added on WooCommerce's "View Order" page. It'll then allow users to print their own invoices.

David
