### PR TITLE
Added 'woocommerce_invoice_print' shortcode.

### DIFF
--- a/woocommerce-delivery-notes.php
+++ b/woocommerce-delivery-notes.php
@@ -181,7 +181,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes' ) ) {
 				return '';
 			}
 
-			$nonce_url = wcdn_get_print_link( $order->id, 'invoice' );
+			$nonce_url = wcdn_get_print_link( $order->id, 'invoice', $order->billing_email);
 			$print_invoice = esc_attr( 'Print Invoice', 'woocommerce-delivery-notes' );
 			$plugin_url = WooCommerce_Delivery_Notes::$plugin_url;
 


### PR DESCRIPTION
It creates a 'Print invoice' button that creates a printable invoice in a new page.
It only needs the order id as arguement.
Example usage: [woocommerce_invoice_print id=133]
