### PR TITLE
Allow orders with any post status to get pulled

### DIFF
--- a/includes/class-wcdn-print.php
+++ b/includes/class-wcdn-print.php
@@ -258,7 +258,7 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes_Print' ) ) {
 			$args = array(
 				'posts_per_page' => -1,
 				'post_type' => 'shop_order',
-				'post_status' => 'publish',
+				'post_status' => 'any',
 				'post__in' => $this->order_ids,
 				'orderby' => 'post__in'
 			);


### PR DESCRIPTION
This was causing a client of mine to have his orders pull a white screen when trying to print.
Did you specifically desire to only pull orders with the publish post status?
If not, this worked for me.
