### PR TITLE
Remove extra blank page when printing

### DIFF
--- a/templates/print-order/style.css
+++ b/templates/print-order/style.css
@@ -115,7 +115,10 @@ tfoot {
 	padding-right: 10%;
 	padding-top: 5%;
 	padding-bottom: 5%;
-	page-break-after: always;
+}
+
+.content + .content {
+	page-break-before: always;
 }
 
 h1,


### PR DESCRIPTION
Changed the page break to only come before a .content div that follows another .content div.
