### PR TITLE
Add support for third-party invoice numbering plugins for WooCommerce

### DIFF
--- a/includes/class-wcdn-print.php
+++ b/includes/class-wcdn-print.php
@@ -420,6 +420,12 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes_Print' ) ) {
 		 * Get the order invoice number
 		 */
 		public function get_order_invoice_number( $order_id ) {						
+			// Let third-party numbering plugins set the invoice number, otherwise use sequential numbers
+			$invnum = apply_filters( 'woocommerce_invoice_number', null, $order_id );
+			if ($invnum) {
+				return apply_filters( 'wcdn_order_invoice_number', $invnum);
+			}
+
 			$invoice_count = intval( get_option( 'wcdn_invoice_number_count', 1 ) );
 			$invoice_prefix = get_option( 'wcdn_invoice_number_prefix' );
 			$invoice_suffix = get_option( 'wcdn_invoice_number_suffix' );

--- a/includes/class-wcdn-settings.php
+++ b/includes/class-wcdn-settings.php
@@ -215,14 +215,14 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Settings' ) ) {
 						'id' 	=> 'display_options'
 					),
 					
-					array( 
+					'invoice_options' => array(
 				        'title' => __( 'Invoice', 'woocommerce-delivery-notes' ), 
 				        'type'  => 'title', 
 				        'desc'  => '', 
 				        'id'    => 'invoice_options' 
 			        ),
 			        
-			        array(
+			        'create_invoice_number' => array(
 						'title'           => __( 'Numbering', 'woocommerce-delivery-notes' ),
 						'desc'            => __( 'Create invoice numbers', 'woocommerce-delivery-notes' ),
 						'id'              => 'wcdn_create_invoice_number',
@@ -231,7 +231,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Settings' ) ) {
 						'desc_tip'        => ''
 					),
 			        
-					array(
+					'invoice_number_count' => array(
 						'title'    => __( 'Next Number', 'woocommerce-delivery-notes' ),
 						'desc'     => '',
 						'id'       => 'wcdn_invoice_number_count',
@@ -242,7 +242,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Settings' ) ) {
 						'desc_tip' =>  __( 'The next invoice number.', 'woocommerce-delivery-notes' )
 					),
 					
-					array(
+					'invoice_number_prefix' => array(
 						'title'    => __( 'Number Prefix', 'woocommerce-delivery-notes' ),
 						'desc'     => '',
 						'id'       => 'wcdn_invoice_number_prefix',
@@ -253,7 +253,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Settings' ) ) {
 						'desc_tip' =>  __( 'This text will be prepended to the invoice number.', 'woocommerce-delivery-notes' )
 					),
 					
-					array(
+					'invoice_number_suffix' => array(
 						'title'    => __( 'Number Suffix', 'woocommerce-delivery-notes' ),
 						'desc'     => '',
 						'id'       => 'wcdn_invoice_number_suffix',
@@ -271,6 +271,21 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Settings' ) ) {
 			    ) 
 		    );
 		    
+			// If a third-party numbering plugin is taking responsibility for invoice numbers,
+			// show a link to the config page and remove the counter settings
+			if (apply_filters('woocommerce_invoice_number_by_plugin', false)) {
+				$config_link = esc_attr(apply_filters('woocommerce_invoice_number_configuration_link', null));
+				$desc = __( 'Invoice numbers are created by a third-party extension.', 'woocommerce-delivery-notes');
+				if ($config_link) {
+					$desc .= ' '.sprintf(__( 'Configure it <a href="%s">here</a>.', 'woocommerce-delivery-notes'), $config_link);
+				}
+				$settings['invoice_options']['desc'] = '<i>'.$desc.'</i>';
+				unset($settings['create_invoice_number']);
+				unset($settings['invoice_number_count']);
+				unset($settings['invoice_number_prefix']);
+				unset($settings['invoice_number_suffix']);
+			}
+
 		    return apply_filters( 'wcdn_get_settings', $settings, $section );
 		}
 		

--- a/includes/wcdn-template-functions.php
+++ b/includes/wcdn-template-functions.php
@@ -229,8 +229,9 @@ function wcdn_get_order_info( $order ) {
 	global $wcdn;
 	$fields = array();
 	$create_invoice_number = get_option( 'wcdn_create_invoice_number' );
+	$thirdparty_invoicenumbers = apply_filters( 'woocommerce_invoice_number_by_plugin', false );
 	
-	if( wcdn_get_template_type() == 'invoice' && !empty( $create_invoice_number ) && $create_invoice_number == 'yes' ) {
+	if( wcdn_get_template_type() == 'invoice' && ((!empty( $create_invoice_number ) && $create_invoice_number == 'yes') || $thirdparty_invoicenumbers) ) {
 		$fields['invoice_number'] = array( 
 			'label' => __( 'Invoice Number', 'woocommerce-delivery-notes' ),
 			'value' => wcdn_get_order_invoice_number( $order->id )


### PR DESCRIPTION
This patch implements the API proposed at http://open-tools.net/blog/63-proposal-for-a-general-api-for-third-party-woocommerce-invoice-numbering-plugins.html for the "WooCommerce Print Invoice and Delivery Notes" by Triggvy Gunderson (woocommerce-delivery-notes)

-) If a third-party invoice number plugin is enabled, use the invoice numbers by that plugin
-) Also hide the counter settings in that case
