### PR TITLE
WooCommerce V3.x.x Compatible

### DIFF
--- a/includes/class-wcdn-print.php
+++ b/includes/class-wcdn-print.php
@@ -388,14 +388,18 @@ if ( ! class_exists( 'WooCommerce_Delivery_Notes_Print' ) ) {
 			foreach( $posts as $post ) {
 				$order = new WC_Order( $post->ID );
 				
+				$wdn_order_id =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_id() : $order->id;
 				// Logged in users			
-				if( is_user_logged_in() && ( !current_user_can( 'edit_shop_orders' ) && !current_user_can( 'view_order', $order->id ) ) ) {
+				if( is_user_logged_in() && ( !current_user_can( 'edit_shop_orders' ) && !current_user_can( 'view_order', $wdn_order_id ) ) ) {
 					$this->orders = null;
 					return false;
 				} 
 
+                $wdn_order_billing_id  =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_billing_email() : $order->billing_email;
+                
+                
 				// An email is required for not logged in users  
-				if( !is_user_logged_in() && ( empty( $this->order_email ) || strtolower( $order->billing_email ) != $this->order_email ) ) {
+				if( !is_user_logged_in() && ( empty( $this->order_email ) || strtolower( $wdn_order_billing_id ) != $this->order_email ) ) {
 					$this->orders = null;
 					return false;
 				}

--- a/includes/class-wcdn-theme.php
+++ b/includes/class-wcdn-theme.php
@@ -51,8 +51,9 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Theme' ) ) {
 		public function create_print_button_account_page( $actions, $order ) {			
 			if( get_option( 'wcdn_print_button_on_my_account_page' ) == 'yes' ) {				
 				// Add the print button
+				$wdn_order_id =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_id() : $order->id;
 				$actions['print'] = array(
-					'url'  => wcdn_get_print_link( $order->id, $this->get_template_type( $order ) ),
+					'url'  => wcdn_get_print_link( $wdn_order_id, $this->get_template_type( $order ) ),
 					'name' => __( 'Print', 'woocommerce-delivery-notes' )
 				);
 			}		
@@ -64,7 +65,7 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Theme' ) ) {
 		 */
 		public function create_print_button_order_page( $order_id ) {
 			$order = new WC_Order( $order_id );
-			
+			$wdn_order_billing_id  =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_billing_email() : $order->billing_email;
 			// Output the button only when the option is enabled
 			if( get_option( 'wcdn_print_button_on_view_order_page' ) == 'yes' ) {				
 				// Default button for all pages and logged in users					
@@ -80,10 +81,10 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Theme' ) ) {
 				// Thank you page
 				if( is_order_received_page() && !is_user_logged_in() ) {
 					// Don't output the butten when there is no email
-					if( !$order->billing_email ) {
+					if( !$wdn_order_billing_id ) {
 						return;
 					}
-					$print_url = wcdn_get_print_link( $order_id, $this->get_template_type( $order ), $order->billing_email );
+					$print_url = wcdn_get_print_link( $order_id, $this->get_template_type( $order ), $wdn_order_billing_id );
 				}
 				
 				?>
@@ -99,8 +100,11 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Theme' ) ) {
 		 */		
 		public function add_email_print_url( $order, $sent_to_admin = true, $plain_text = false ) {
 			if( get_option( 'wcdn_email_print_link' ) == 'yes' ) {				
-				if( $order->billing_email && !$sent_to_admin ) {
-					$url = wcdn_get_print_link( $order->id, $this->get_template_type( $order ), $order->billing_email, true );
+			    $wdn_order_billing_id  =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_billing_email() : $order->billing_email;
+				if( $wdn_order_billing_id && !$sent_to_admin ) {
+				    $wdn_order_id =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_id() : $order->id;
+				    
+					$url = wcdn_get_print_link( $wdn_order_id, $this->get_template_type( $order ), $wdn_order_billing_id, true );
 					
 					if( $plain_text ) :
 echo __( 'Print your order', 'woocommerce-delivery-notes' ) . "\n\n";
@@ -119,7 +123,10 @@ echo "\n****************************************************\n\n";
 		 * Get the print button template type depnding on order status
 		 */
 		public function get_template_type( $order ) {
-			if( $order->status == 'completed' ) {
+		    
+		    $wdn_order_status =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_status() : $order->status;
+		    
+			if( $wdn_order_status == 'completed' ) {
 				$type = apply_filters( 'wcdn_theme_print_button_template_type_complete_status', 'invoice' );
 			} else {
 				$type = apply_filters( 'wcdn_theme_print_button_template_type', 'order' );

--- a/includes/class-wcdn-writepanel.php
+++ b/includes/class-wcdn-writepanel.php
@@ -87,11 +87,13 @@ if ( !class_exists( 'WooCommerce_Delivery_Notes_Writepanel' ) ) {
 		 * Add print actions to the orders listing
 		 */
 		public function add_listing_actions( $order ) {
+		    
+		    $wdn_order_id =  ( version_compare( get_option( 'woocommerce_version' ), '3.0.0', ">="  ) ) ? $order->get_id() : $order->id;
 			?>
 			<?php foreach( WooCommerce_Delivery_Notes_Print::$template_registrations as $template_registration ) : ?>
 				<?php if( get_option( 'wcdn_template_type_' . $template_registration['type'] ) == 'yes' && $template_registration['type'] !== 'order' ) : ?>
 				
-					<a href="<?php echo wcdn_get_print_link( $order->id, $template_registration['type'] ); ?>" class="button tips print-preview-button <?php echo $template_registration['type']; ?>" target="_blank" alt="<?php esc_attr_e( __( $template_registration['labels']['print'], 'woocommerce-delivery-notes' ) ); ?>" data-tip="<?php esc_attr_e( __( $template_registration['labels']['print'], 'woocommerce-delivery-notes' ) ); ?>">
+					<a href="<?php echo wcdn_get_print_link( $wdn_order_id, $template_registration['type'] ); ?>" class="button tips print-preview-button <?php echo $template_registration['type']; ?>" target="_blank" alt="<?php esc_attr_e( __( $template_registration['labels']['print'], 'woocommerce-delivery-notes' ) ); ?>" data-tip="<?php esc_attr_e( __( $template_registration['labels']['print'], 'woocommerce-delivery-notes' ) ); ?>">
 						<?php _e( $template_registration['labels']['print'], 'woocommerce-delivery-notes' ); ?>
 					</a>
 					

--- a/templates/print-order/print-content.php
+++ b/templates/print-order/print-content.php
@@ -80,7 +80,13 @@ if ( !defined( 'ABSPATH' ) ) exit;
 									
 									<?php
 										$product = apply_filters( 'wcdn_order_item_product', $order->get_product_from_item( $item ), $item );
-										$item_meta = new WC_Order_Item_Meta( $item['item_meta'], $product );
+										
+										if ( version_compare( get_option( 'woocommerce_version' ), '3.1.0', ">="  ) ) {
+										    $item_meta = new WC_Order_Item_Product( $item['item_meta'], $product );
+										}else{
+										    $item_meta = new WC_Order_Item_Meta( $item['item_meta'], $product );    
+										} 
+										
 									?>
 									
 									<tr>
@@ -89,7 +95,15 @@ if ( !defined( 'ABSPATH' ) ) exit;
 
 											<span class="name"><?php echo apply_filters( 'wcdn_order_item_name', $item['name'], $item ); ?></span>
 
-											<?php $item_meta->display(); ?>
+											<?php 
+											if ( version_compare( get_option( 'woocommerce_version' ), '3.1.0', ">="  ) ) {
+											    $item_meta->get_product(); 
+											
+											}else {
+											    
+											    $item_meta->display(); 
+											}
+											?>
 											
 											<dl class="extras">
 												<?php if( $product && $product->exists() && $product->is_downloadable() && $order->is_download_permitted() ) : ?>


### PR DESCRIPTION
In this commit we have fixed the warning displyed on the Print screens, on the admin side it was shwoing notice on the WC orders columns.

Also, when customer click on the print view from the email then the notices was displayed

Also, the My Account page was showing the notices on the Print

All these notices has been fixed.

It is also made compatible with the latest WC version as well as with Older version